### PR TITLE
[codex] 雑音誤検知とVoskモデル読込失敗への耐性を改善する

### DIFF
--- a/src/mituke/bot/commands.py
+++ b/src/mituke/bot/commands.py
@@ -33,7 +33,7 @@ async def start_listening(
         recognizer = VoskRecognizer(model_path=settings.vosk_model_path)
     except Exception as error:
         handle_listen_error(error)
-        await ctx.send(messages.vosk_model_load_failed(settings.vosk_model_path))
+        await ctx.send(messages.vosk_model_load_failed())
         return
 
     target_channel = voice_state.channel

--- a/src/mituke/bot/commands.py
+++ b/src/mituke/bot/commands.py
@@ -29,6 +29,13 @@ async def start_listening(
         await ctx.send(messages.VOICE_CHANNEL_REQUIRED)
         return
 
+    try:
+        recognizer = VoskRecognizer(model_path=settings.vosk_model_path)
+    except Exception as error:
+        handle_listen_error(error)
+        await ctx.send(messages.vosk_model_load_failed(settings.vosk_model_path))
+        return
+
     target_channel = voice_state.channel
     voice_client = ctx.guild.voice_client
 
@@ -57,7 +64,7 @@ async def start_listening(
 
     sink = TranscriptionSink(
         text_channel=ctx.channel,
-        recognizer=VoskRecognizer(model_path=settings.vosk_model_path),
+        recognizer=recognizer,
         loop=asyncio.get_running_loop(),
     )
 

--- a/src/mituke/bot/messages.py
+++ b/src/mituke/bot/messages.py
@@ -36,11 +36,8 @@ def listen_error(error: Exception) -> str:
     return f"音声処理でエラーが発生しました: {error}"
 
 
-def vosk_model_load_failed(model_path: object) -> str:
-    return (
-        "音声認識モデルを読み込めませんでした。"
-        f" `VOSK_MODEL_PATH` を確認してください: {model_path}"
-    )
+def vosk_model_load_failed() -> str:
+    return "音声認識モデルを読み込めませんでした。ログを確認してください。"
 
 
 def command_error(error: Exception) -> str:

--- a/src/mituke/bot/messages.py
+++ b/src/mituke/bot/messages.py
@@ -33,7 +33,14 @@ def logged_in_as(user: object) -> str:
 
 
 def listen_error(error: Exception) -> str:
-    return f"音声を受信しているときにエラーが発生しました: {error}"
+    return f"音声処理でエラーが発生しました: {error}"
+
+
+def vosk_model_load_failed(model_path: object) -> str:
+    return (
+        "音声認識モデルを読み込めませんでした。"
+        f" `VOSK_MODEL_PATH` を確認してください: {model_path}"
+    )
 
 
 def command_error(error: Exception) -> str:

--- a/src/mituke/transcription/audio.py
+++ b/src/mituke/transcription/audio.py
@@ -12,7 +12,8 @@ from discord.opus import Decoder
 PCM_SAMPLE_WIDTH_BYTES = 2
 VOSK_SAMPLE_RATE = 16000
 VOICE_ACTIVITY_FRAME_MS = 20
-VOICE_ACTIVITY_RMS_THRESHOLD = 250
+VOICE_ACTIVITY_RMS_THRESHOLD = 500
+VOICE_ACTIVITY_START_MIN_FRAMES = 3
 
 
 def _to_mono_pcm(pcm: bytes, channels: int) -> bytes:
@@ -77,6 +78,7 @@ def trim_leading_silence(
     sample_width: int = PCM_SAMPLE_WIDTH_BYTES,
     rms_threshold: int = VOICE_ACTIVITY_RMS_THRESHOLD,
     frame_duration_ms: int = VOICE_ACTIVITY_FRAME_MS,
+    min_voiced_frames: int = 1,
     preroll_frames: int = 1,
 ) -> bytes:
     aligned_pcm = _align_pcm_samples(pcm, sample_width)
@@ -90,7 +92,9 @@ def trim_leading_silence(
     if frame_size % sample_width != 0:
         frame_size += sample_width - (frame_size % sample_width)
 
+    consecutive_voiced_frames = 0
     first_voiced_offset: int | None = None
+    speech_start_offset: int | None = None
     for offset in range(0, len(aligned_pcm), frame_size):
         frame = aligned_pcm[offset : offset + frame_size]
         if has_voice_activity(
@@ -98,13 +102,21 @@ def trim_leading_silence(
             sample_width=sample_width,
             rms_threshold=rms_threshold,
         ):
-            first_voiced_offset = offset
-            break
+            consecutive_voiced_frames += 1
+            if first_voiced_offset is None:
+                first_voiced_offset = offset
+            if consecutive_voiced_frames >= max(1, min_voiced_frames):
+                speech_start_offset = first_voiced_offset
+                break
+            continue
 
-    if first_voiced_offset is None:
+        consecutive_voiced_frames = 0
+        first_voiced_offset = None
+
+    if speech_start_offset is None:
         return b""
 
-    start_offset = max(0, first_voiced_offset - (preroll_frames * frame_size))
+    start_offset = max(0, speech_start_offset - (preroll_frames * frame_size))
     return aligned_pcm[start_offset:]
 
 

--- a/src/mituke/transcription/model.py
+++ b/src/mituke/transcription/model.py
@@ -8,7 +8,16 @@ from vosk import Model
 console = Console()
 
 
+class VoskModelLoadError(RuntimeError):
+    """Vosk モデルの初期化に失敗したことを表す。"""
+
+
 @lru_cache(maxsize=4)
 def load_vosk_model(model_path: str) -> Model:
     console.log(f"Vosk モデルを読み込みます: {model_path}")
-    return Model(model_path)
+    try:
+        return Model(model_path)
+    except Exception as error:
+        raise VoskModelLoadError(
+            f"Vosk モデルを読み込めませんでした: {model_path}"
+        ) from error

--- a/src/mituke/transcription/sink.py
+++ b/src/mituke/transcription/sink.py
@@ -14,6 +14,8 @@ from rich.console import Console
 
 from mituke.transcription.audio import (
     PCM_SAMPLE_WIDTH_BYTES,
+    VOICE_ACTIVITY_START_MIN_FRAMES,
+    VOSK_SAMPLE_RATE,
     convert_pcm_48khz_stereo_to_16khz_mono,
     trim_leading_silence,
 )
@@ -29,6 +31,7 @@ PENDING_AUDIO_MAX_BYTES = (
     Decoder.SAMPLING_RATE * Decoder.CHANNELS * PCM_SAMPLE_WIDTH_BYTES
 )
 SPEECH_STOP_GRACE_SECONDS = 0.8
+PRE_START_BUFFER_MAX_BYTES = VOSK_SAMPLE_RATE * PCM_SAMPLE_WIDTH_BYTES
 
 
 class TranscriptionSink(AudioSink):
@@ -193,10 +196,19 @@ class TranscriptionSink(AudioSink):
                 return
 
             if not current_state.start_announced:
-                mono_16khz_pcm = trim_leading_silence(mono_16khz_pcm)
+                current_state.pre_start_pcm.extend(mono_16khz_pcm)
+                if len(current_state.pre_start_pcm) > PRE_START_BUFFER_MAX_BYTES:
+                    del current_state.pre_start_pcm[:-PRE_START_BUFFER_MAX_BYTES]
+
+                mono_16khz_pcm = trim_leading_silence(
+                    bytes(current_state.pre_start_pcm),
+                    min_voiced_frames=VOICE_ACTIVITY_START_MIN_FRAMES,
+                    preroll_frames=0,
+                )
                 if not mono_16khz_pcm:
                     return
 
+                current_state.pre_start_pcm.clear()
                 current_state.start_announced = True
                 should_queue_start = True
 

--- a/src/mituke/transcription/state.py
+++ b/src/mituke/transcription/state.py
@@ -24,6 +24,7 @@ class RecognitionState:
     partial_text: str = ""
     last_partial_sent_at: float = 0.0
     resample_state: Any = None
+    pre_start_pcm: bytearray = field(default_factory=bytearray)
     start_announced: bool = False
     activity_token: int = 0
 

--- a/tests/test_bot_commands.py
+++ b/tests/test_bot_commands.py
@@ -294,7 +294,7 @@ class StartListeningTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(target_channel.connect_calls, [])
         self.assertEqual(
             ctx.sent_messages,
-            [vosk_model_load_failed(settings.vosk_model_path)],
+            [vosk_model_load_failed()],
         )
 
 

--- a/tests/test_bot_commands.py
+++ b/tests/test_bot_commands.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from mituke.bot.commands import show_help, start_listening, stop_listening
+from mituke.bot.messages import vosk_model_load_failed
 from mituke.config import Settings
 
 
@@ -269,6 +270,32 @@ class StartListeningTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(voice_client._ssrc_to_id, {})
         self.assertEqual(voice_client._id_to_ssrc, {})
+
+    async def test_reports_model_load_failure_before_joining_voice(self) -> None:
+        settings = Settings("token", Path("broken-model"), None)
+        handle_listen_error = Mock()
+        target_channel = FakeVoiceChannel("General")
+        ctx = FakeContext(
+            guild=FakeGuild(),
+            author=FakeMember(voice=SimpleNamespace(channel=target_channel)),
+            channel=FakeTextChannel(),
+        )
+
+        with (
+            patch("mituke.bot.commands.discord.Member", FakeMember),
+            patch(
+                "mituke.bot.commands.VoskRecognizer",
+                side_effect=RuntimeError("invalid model"),
+            ),
+        ):
+            await start_listening(ctx, settings, handle_listen_error)
+
+        handle_listen_error.assert_called_once()
+        self.assertEqual(target_channel.connect_calls, [])
+        self.assertEqual(
+            ctx.sent_messages,
+            [vosk_model_load_failed(settings.vosk_model_path)],
+        )
 
 
 class StopListeningTests(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_transcription_helpers.py
+++ b/tests/test_transcription_helpers.py
@@ -126,9 +126,11 @@ class ConvertPcmTests(unittest.TestCase):
 
     def test_detects_voice_activity_from_non_silent_pcm(self) -> None:
         silent_pcm = array("h", [0] * 320).tobytes()
+        noise_pcm = array("h", [350] * 320).tobytes()
         voiced_pcm = array("h", [1200] * 320).tobytes()
 
         self.assertFalse(has_voice_activity(silent_pcm))
+        self.assertFalse(has_voice_activity(noise_pcm))
         self.assertTrue(has_voice_activity(voiced_pcm))
 
     def test_trims_leading_silence_before_first_voiced_frame(self) -> None:
@@ -141,3 +143,15 @@ class ConvertPcmTests(unittest.TestCase):
         )
 
         self.assertEqual(trimmed, voiced_frame)
+
+    def test_requires_sustained_voice_when_min_voiced_frames_is_set(self) -> None:
+        silent_frame = array("h", [0] * 320).tobytes()
+        voiced_frame = array("h", [1600] * 320).tobytes()
+
+        trimmed = trim_leading_silence(
+            silent_frame + voiced_frame + silent_frame,
+            min_voiced_frames=2,
+            preroll_frames=0,
+        )
+
+        self.assertEqual(trimmed, b"")

--- a/tests/test_transcription_sink.py
+++ b/tests/test_transcription_sink.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from mituke.transcription.sink import TranscriptionSink
-from mituke.transcription.state import MessageState
+from mituke.transcription.state import MessageState, RecognitionTask
 
 
 class FakeRecognizer:
@@ -144,13 +144,17 @@ class TranscriptionSinkTests(unittest.IsolatedAsyncioTestCase):
             user,
             SimpleNamespace(pcm=tail_pcm, packet=SimpleNamespace(ssrc=42)),
         )
+        sink.write(
+            user,
+            SimpleNamespace(pcm=tail_pcm, packet=SimpleNamespace(ssrc=42)),
+        )
 
         await asyncio.wait_for(sink.wait_for_idle(), 1)
 
         state = sink.recognition_states[1]
         recognizer = state.recognizer
 
-        self.assertEqual(recognizer.accept_calls, [lead_pcm + tail_pcm])
+        self.assertEqual(recognizer.accept_calls, [lead_pcm + tail_pcm + tail_pcm])
         self.assertEqual(len(self.text_channel.messages), 1)
         self.assertEqual(self.text_channel.messages[0].content, "Alice: あとから")
         self.assertEqual(
@@ -172,6 +176,20 @@ class TranscriptionSinkTests(unittest.IsolatedAsyncioTestCase):
 
         user = SimpleNamespace(id=1, display_name="Alice", bot=False)
         sink.on_voice_member_speaking_start(user)
+        sink.write(
+            user,
+            SimpleNamespace(
+                pcm=self._make_pcm(1200),
+                packet=SimpleNamespace(ssrc=42),
+            ),
+        )
+        sink.write(
+            user,
+            SimpleNamespace(
+                pcm=self._make_pcm(1200),
+                packet=SimpleNamespace(ssrc=42),
+            ),
+        )
         sink.write(
             user,
             SimpleNamespace(
@@ -217,12 +235,47 @@ class TranscriptionSinkTests(unittest.IsolatedAsyncioTestCase):
         sink.request_stop()
         await sink.wait_closed()
 
+    async def test_brief_noise_does_not_trigger_transcription_start(self) -> None:
+        sink = TranscriptionSink(
+            text_channel=self.text_channel,
+            recognizer=self.recognizer_factory,
+            loop=self.loop,
+        )
+
+        user = SimpleNamespace(id=1, display_name="Alice", bot=False)
+        noise = SimpleNamespace(
+            pcm=self._make_pcm(350),
+            packet=SimpleNamespace(ssrc=42),
+        )
+        speech = SimpleNamespace(
+            pcm=self._make_pcm(1200),
+            packet=SimpleNamespace(ssrc=42),
+        )
+
+        sink.write(user, noise)
+        await asyncio.wait_for(sink.wait_for_idle(), 1)
+
+        recognizer = sink.recognition_states[1].recognizer
+        self.assertEqual(recognizer.accept_calls, [])
+        self.assertEqual(self.text_channel.messages, [])
+
+        sink.write(user, speech)
+        sink.write(user, speech)
+        sink.write(user, speech)
+        await asyncio.wait_for(sink.wait_for_idle(), 1)
+
+        self.assertEqual(recognizer.accept_calls, [speech.pcm * 3])
+        self.assertEqual(len(self.text_channel.messages), 1)
+        self.assertEqual(self.text_channel.messages[0].content, "Alice: あとから")
+
+        sink.request_stop()
+        await sink.wait_closed()
+
     async def test_brief_pause_keeps_same_transcription_session(self) -> None:
         sink = TranscriptionSink(
             text_channel=self.text_channel,
             recognizer=self.recognizer_factory,
             loop=self.loop,
-            speech_stop_grace_period=0.05,
         )
 
         user = SimpleNamespace(id=1, display_name="Alice", bot=False)
@@ -231,14 +284,24 @@ class TranscriptionSinkTests(unittest.IsolatedAsyncioTestCase):
         )
 
         sink.write(user, audio)
+        sink.write(user, audio)
+        sink.write(user, audio)
         await asyncio.wait_for(sink.wait_for_idle(), 1)
+        previous_token = sink.recognition_states[1].activity_token
 
         sink.on_voice_member_speaking_stop(user)
-        await asyncio.sleep(0.02)
         sink.on_voice_member_speaking_start(user)
         sink.write(user, audio)
         await asyncio.wait_for(sink.wait_for_idle(), 1)
-        await asyncio.sleep(0.06)
+
+        sink._process_stop_timeout(
+            RecognitionTask(
+                kind="stop_timeout",
+                user_id=1,
+                display_name="Alice",
+                token=previous_token,
+            )
+        )
         await asyncio.wait_for(sink.wait_for_idle(), 1)
 
         self.assertEqual(len(self.text_channel.messages), 1)


### PR DESCRIPTION
## 概要
- 話し始め判定の前に短い音声バッファを持ち、単発の雑音では文字起こしを開始しないようにしました
- `!join` 実行時に Vosk モデルの読み込み失敗を先に検出し、VC 参加前に利用者へ案内を返すようにしました
- 関連するテストを追加し、開始判定まわりのタイミング依存テストも安定化しました

## 原因
- これまでの開始判定は、閾値を 1 フレームだけ超えた雑音でも発話開始とみなしていました
- Vosk モデルの初期化失敗は `!join` 実行中にそのまま例外化され、利用者には原因が分かりにくい状態でした

## 影響
- 軽い雑音だけで不要な文字起こしメッセージが立つ頻度を下げられます
- モデル配置が壊れている環境でも Bot が半端に VC 参加せず、設定確認メッセージを返せます

## 確認
- `./.venv/Scripts/python.exe -m unittest discover -s tests -v`

Closes #24
